### PR TITLE
Add scripts for downloading sqlite database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata
+Capstone-Project-JnJ.Rproj

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,3 @@
+# Changelog
+
+* (2021-01-31) Added README for documenting information and changes.

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,8 @@
+# Ignore everything
+*
+
+# But not these files...
+!.gitignore
+!README.md
+!get_data.py
+!get_data.R

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,17 @@
+# `data`
+
+Store data here for local usage only, everything except this README file should be ignored.
+
+## Database Information
+
+The data being pulled from `Resolute.AI` is very relational, this is why things are separated into individual tables. There are a couple of tables that will always be included in the database:
+
+1. `base`: this is the "base" table that everything else is based off of. It's not of much use so it can mostly be ignored.
+2. `products`: this has jnj product names and categories with the associated company. This may be useful when performing queries.
+3. `requests`: this is a record of all requests that were made in order to create the database.
+
+The naming convension of all other tables goes like this:
+
+* (endpoint)_(nested / relational data)
+
+So for example, the `search/news/` endpoint has a nested column with company topic information. Therefore, the resulting table is named `search_news_company_topics`.

--- a/data/get_data.R
+++ b/data/get_data.R
@@ -1,0 +1,13 @@
+library(aws.s3)
+library(readr)
+
+# set default region to us-west-1, R thinks you want us-east-1
+Sys.setenv(AWS_DEFAULT_REGION = "us-west-1")
+
+x <- get_object(
+  object = "jnj_capstone.sqlite",
+  bucket = "jnj-capstone-2022", 
+  file = "data/jnj_capstone-r.sqlite"
+)
+
+write_file(x, "data/jnj_capstone.sqlite")

--- a/data/get_data.py
+++ b/data/get_data.py
@@ -1,0 +1,14 @@
+# set up credentials: https://docs.aws.amazon.com/cli/latest/userguide/welcome-examples.html
+
+import boto3
+import sqlite3
+import pandas as pd
+ 
+s3 = boto3.client('s3')
+s3.download_file('jnj-capstone-2022', 'jnj_capstone.sqlite', 'data/jnj_capstone.sqlite')
+con = sqlite3.connect('data/jnj_capstone.sqlite')
+
+df = pd.read_sql_query("select * from requests", con)
+print(df.head())
+
+con.close()


### PR DESCRIPTION
This pull request adds:

1. Scripts in python and R for downloading the sqlite database from S3. If you have your credentials set up (using the aws cli), the scripts should run without error.
2. A folder `data`, we will store all data in this folder. The folder intentionally ignores almost everything in it so that we don't accidentally track large objects in `git`.
3. Information on the database in its current state, see `data/README.md` file.
4. A `NEWS.md` file to track changes.